### PR TITLE
```

### DIFF
--- a/src/core/services/reports/SalesReport.ts
+++ b/src/core/services/reports/SalesReport.ts
@@ -250,8 +250,11 @@ export class SalesReportService {
       payment_methods: paymentMethods,
       categories,
       cashiers,
+      // Keep package-inclusive dataset exposed for backwards compatibility
       all_products_sold: allProductsAndPackagesSold,
-      all_products_sold_standalone: allProductsAndPackagesSold,
+      // Standalone view should list actual individual products only
+      all_products_sold_standalone: allProductsSold,
+      // Combined view expands packages into their component products for consumption tracking
       all_products_sold_combined: allProductsSoldCombined,
     };
   }

--- a/src/views/pos/PrintableReceipt.tsx
+++ b/src/views/pos/PrintableReceipt.tsx
@@ -472,13 +472,6 @@ export function PrintableReceipt({ orderData, isPrintMode = false, variant = 'br
             </>
           )}
           
-          {order.table && (
-            <>
-              <div className="text-black">Table:</div>
-              <div className="text-right font-semibold">Table {order.table.table_number}</div>
-            </>
-          )}
-          
           {order.customer && (
             <>
               <div className="text-black">Customer:</div>
@@ -486,6 +479,30 @@ export function PrintableReceipt({ orderData, isPrintMode = false, variant = 'br
             </>
           )}
         </div>
+
+        {order.table && (
+          <div
+            className="border border-black rounded-md text-center"
+            style={{
+              marginTop: '6px',
+              padding: '6px 8px',
+              backgroundColor: isPrintMode ? '#f5f5f5' : undefined,
+            }}
+          >
+            <p
+              className="font-semibold uppercase text-black"
+              style={{ fontSize: '10px', letterSpacing: '0.08em', marginBottom: '2px' }}
+            >
+              Table Assignment
+            </p>
+            <p
+              className="font-black text-black tracking-widest"
+              style={{ fontSize: '20px', lineHeight: '1' }}
+            >
+              {order.table.table_number}
+            </p>
+          </div>
+        )}
       </div>
 
       {/* Divider - Minimal */}


### PR DESCRIPTION
fix: correct standalone sales report to exclude packages and enhance receipt table display

- Fixed all_products_sold_standalone to return only individual products (allProductsSold) instead of package-inclusive dataset
- Added inline documentation clarifying three product datasets: package-inclusive (backwards compatibility), standalone (individual products only), and combined (packages expanded to components)
- Redesigned receipt table assignment section with prominent bordered card layout featuring