### PR TITLE
```

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beerhive-pos",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "engines": {
     "node": ">=18.17.0"

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -11,7 +11,7 @@ export async function GET() {
     status: 'healthy',
     timestamp: new Date().toISOString(),
     message: 'BeerHive POS API is running',
-    version: '1.1.1',
+    version: '1.1.2',
     phase: 'Production - Feature Complete'
   });
 }

--- a/src/data/queries/reports.queries.ts
+++ b/src/data/queries/reports.queries.ts
@@ -130,7 +130,7 @@ export async function getDailySalesSummary(startDate: string, endDate: string) {
     .from('order_items')
     .select(`
       quantity,
-      order:order_id(completed_at, status),
+      order:orders!inner(completed_at, status),
       product:product_id(base_price, cost_price)
     `)
     .gte('order.completed_at', startDate)
@@ -237,7 +237,7 @@ export async function getTopProducts(startDate: string, endDate: string, limit =
       item_name,
       quantity,
       total,
-      order:order_id(completed_at, status)
+      order:orders!inner(completed_at, status)
     `)
     .gte('order.completed_at', startDate)
     .lte('order.completed_at', endDate)
@@ -286,7 +286,7 @@ export async function getAllProductsSold(startDate: string, endDate: string) {
       item_name,
       quantity,
       total,
-      order:order_id(completed_at, status)
+      order:orders!inner(completed_at, status)
     `)
     .gte('order.completed_at', startDate)
     .lte('order.completed_at', endDate)
@@ -334,7 +334,7 @@ export async function getAllProductsAndPackagesSold(startDate: string, endDate: 
       item_name,
       quantity,
       total,
-      order:order_id(completed_at, status),
+      order:orders!inner(completed_at, status),
       product:product_id(base_price, cost_price)
     `)
     .gte('order.completed_at', startDate)
@@ -376,7 +376,7 @@ export async function getAllProductsAndPackagesSold(startDate: string, endDate: 
       item_name,
       quantity,
       total,
-      order:order_id(completed_at, status),
+      order:orders!inner(completed_at, status),
       package:package_id(base_price, cost_price)
     `)
     .gte('order.completed_at', startDate)
@@ -433,7 +433,7 @@ export async function getAllProductsSoldCombined(startDate: string, endDate: str
       product_id,
       item_name,
       quantity,
-      order:order_id(completed_at, status)
+      order:orders!inner(completed_at, status)
     `)
     .gte('order.completed_at', startDate)
     .lte('order.completed_at', endDate)
@@ -467,7 +467,7 @@ export async function getAllProductsSoldCombined(startDate: string, endDate: str
     .from('order_items')
     .select(`
       quantity,
-      order:order_id(completed_at, status),
+      order:orders!inner(completed_at, status),
       package:packages!inner(
         id,
         name,
@@ -588,7 +588,7 @@ export async function getSalesByCategory(startDate: string, endDate: string) {
       product:product_id(
         category:category_id(id, name)
       ),
-      order:order_id(completed_at, status)
+      order:orders!inner(completed_at, status)
     `)
     .gte('order.completed_at', startDate)
     .lte('order.completed_at', endDate)
@@ -848,7 +848,7 @@ export async function getInventoryTurnover(startDate: string, endDate: string) {
       product_id,
       item_name,
       quantity,
-      order:order_id(completed_at, status)
+      order:orders!inner(completed_at, status)
     `)
     .gte('order.completed_at', startDate)
     .lte('order.completed_at', endDate)

--- a/src/lib/constants/version.ts
+++ b/src/lib/constants/version.ts
@@ -11,4 +11,4 @@ export const APP_NAME = 'BeerHive POS';
  * Semantic application version.
  * Visible on the login page and the sidebar.
  */
-export const APP_VERSION = '1.1.1';
+export const APP_VERSION = '1.1.2';


### PR DESCRIPTION
chore: bump version to 1.1.2 and fix Supabase foreign key join syntax

- Updated version from 1.1.1 to 1.1.2 across package.json, health endpoint, and version constants
- Fixed deprecated Supabase join syntax by replacing `order:order_id` with `order:orders!inner` across all report queries
- Applied fix to 9 query functions: getDailySalesSummary, getTopProducts, getAllProductsSold, getAllProductsAndPackagesSold, getAllProductsSoldCombined, getSalesByCategory, and getInventoryTurnover
- Ensures